### PR TITLE
Change import statement for jitclass

### DIFF
--- a/src/alphaimpute2/Imputation/Imputation.py
+++ b/src/alphaimpute2/Imputation/Imputation.py
@@ -1,5 +1,6 @@
 import numba
-from numba import jit, int8, int32, boolean, jitclass, float32, int64
+from numba import jit, int8, int32, boolean, float32, int64
+from numba.experimental import jitclass
 import numpy as np
 
 

--- a/src/alphaimpute2/Imputation/ParticleImputation.py
+++ b/src/alphaimpute2/Imputation/ParticleImputation.py
@@ -4,7 +4,8 @@ import random
 import concurrent.futures
 
 from numba.typed import List
-from numba import njit, jit, jitclass, prange
+from numba import njit, jit, prange
+from numba.experimental import jitclass
 
 from collections import OrderedDict
 from itertools import repeat


### PR DESCRIPTION
Had some problems due to importing jitclass from numba vs. numba.experimental (https://github.com/numba/numba/issues/4638#issuecomment-752243891)