### PR TITLE
Modify setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 from setuptools import Extension, find_packages
-import numpy
+# import numpy
 import os
 import glob
 from sys import platform


### PR DESCRIPTION
Delete the line that imports the ``numpy`` package which is not used in the file but would cause ``ModuleNotFoundError`` in a newly created environment.