### PR TITLE
Cleanup issues AlphaGenes/AlphaImpute2#64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ jobs:
         strategy:
           matrix:
             os: [ubuntu-latest, Windows-latest, macos-latest]
+            python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import operator
 import os
 import shutil
+import warnings
 import numpy as np
 
 
@@ -50,13 +51,22 @@ def pytest_runtest_makereport():
             num_file = 3
         else:
             num_file = 2
-        accu = stdout[-1][-1].split("\n")[-(2 + 3 * num_file) :]
-        name = accu[0].split()[-1]
-        with open("tests/accuracy_tests/accu_report.txt", "a") as file:
-            for i in range(num_file):
-                assessed_file = accu[i * 3 + 1].split()[-1]
-                file.write(name + " " + assessed_file + " " + accu[i * 3 + 2] + "\n")
-                file.write(name + " " + assessed_file + " " + accu[i * 3 + 3] + "\n")
+        try:
+            accu = stdout[-1][-1].split("\n")[-(2 + 3 * num_file) :]
+            name = accu[0].split()[-1]
+            with open("tests/accuracy_tests/accu_report.txt", "a") as file:
+                for i in range(num_file):
+                    assessed_file = accu[i * 3 + 1].split()[-1]
+                    file.write(
+                        name + " " + assessed_file + " " + accu[i * 3 + 2] + "\n"
+                    )
+                    file.write(
+                        name + " " + assessed_file + " " + accu[i * 3 + 3] + "\n"
+                    )
+        except IndexError:
+            warnings.warn(
+                "Some outputs may be missing for the generation for the accuracy report. You can check tests/accuracy_tests/accu_report.txt for the recorded accuracies or rerun the tests. "
+            )
 
 
 @pytest.hookimpl()
@@ -88,7 +98,15 @@ def pytest_terminal_summary(terminalreporter):
         "Gen5 Accu",
     )
     dt = {"names": columns, "formats": ("U76", "U28", "U25") + ("f4",) * (nGen + 1)}
-    accu = np.loadtxt("tests/accuracy_tests/accu_report.txt", encoding=None, dtype=dt)
+    try:
+        accu = np.loadtxt(
+            "tests/accuracy_tests/accu_report.txt", encoding=None, dtype=dt
+        )
+    except ValueError:
+        warnings.warn(
+            "Some outputs may be missing for the generation for the accuracy report. You can check tests/accuracy_tests/accu_report.txt for the recorded accuracies or rerun the tests. "
+        )
+        return
 
     mkr_accu = list(
         filter(

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,7 +8,11 @@ Usage
 Program options
 ===============
 
-|Software| takes in a number of command line arguments to control the program's behavior. To view a list of arguments, run |Software| without any command line arguments, i.e. |Software| or ``AlphaImpute2 -h``. 
+|Software| takes in a number of command line arguments to control the program's behavior. To view a list of arguments, run |Software| without any command line arguments, i.e. |Software|, ``AlphaImpute2 -h``, ``AlphaImpute2 -help`` or ``AlphaImpute2 --help``. 
+
+User can check the version of the program with ``AlphaImpute2 -version``. 
+Remember to use the correct version of the documentation for the version of the program you are using.
+For example, the link to the documentation for version ``v0.0.3`` is https://alphaimpute2.readthedocs.io/en/v0.0.3/.
 
 There are four primary ways to run |Software| which differ on whether population or pedigree imputation should be run. The default option is to run both population and pedigree imputation in an integrated algorithm. This will be the option most users will want if they have access to pedigree data on a majority of individuals. The second option is to run population imputation only with the ``-pop_only`` flag. This option should be used if no pedigree data is availible. The third option is to run only pedigree based imputation using the ``-ped_only`` flag. This option is not recommended for general use cases, but may be applicable if 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy>=1.19",
     "numba>=0.49.0"
 ]
-requires-python = "!= 3.12, !=3.14"
+requires-python = ">= 3.6, < 3.14"
 
 [project.scripts]
 # correspond to entry_points

--- a/src/alphaimpute2/Imputation/ImputationIndividual.py
+++ b/src/alphaimpute2/Imputation/ImputationIndividual.py
@@ -20,8 +20,8 @@ if not ("profile" in globals()):
 
 
 class AlphaImputeIndividual(Pedigree.Individual):
-    def __init__(self, idx, idn):
-        super().__init__(idx, idn)
+    def __init__(self, idx, idn, MetaFounder=None):
+        super().__init__(idx, idn, MetaFounder=None)
 
         self.reverse_view = None
         self.backward_information = None

--- a/src/alphaimpute2/alphaimpute2.py
+++ b/src/alphaimpute2/alphaimpute2.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import numpy as np
 
 from .tinyhouse import Pedigree
@@ -13,10 +14,9 @@ from .Imputation import ArrayClustering
 
 from .tinyhouse.Utils import time_func
 
-# try:
 from .Imputation import version
 
-version_verion = version.version
+version_version = version.version
 
 if not ("profile" in globals()):
 
@@ -239,6 +239,21 @@ def getArgs():
         required=False,
         help=argparse.SUPPRESS,
     )  # help='Flag to prioritze pedigree imputation for individuals at the same genotyping density as their parents.')
+
+    # special handle for version argument to allow it to be called with just -version
+    parser.add_argument(
+        "-version",
+        default=None,
+        action="version",
+        version="%(prog)s " + version_version,
+        help="Show program's version number and exit.",
+    )
+
+    args = sys.argv[1:]
+
+    if "-version" in args:
+        parser.parse_args(args)
+        sys.exit(0)
 
     return InputOutput.parseArgs("AlphaImpute", parser)
 
@@ -472,11 +487,13 @@ def write_seg(pedigree, outputFile):
 
 @time_func("Full Program Run")
 def main():
-    InputOutput.print_boilerplate("AlphaImpute2", version_verion)
     args = getArgs()
+
+    InputOutput.print_boilerplate("AlphaImpute2", version_version)
 
     InputOutput.setNumbaSeeds(12345)
     pedigree = Pedigree.Pedigree(constructor=ImputationIndividual.AlphaImputeIndividual)
+    args.main_metafounder = "MF_1"
     read_in_data(pedigree, args)
     for ind in pedigree:
         ind.map_length = args.length


### PR DESCRIPTION
## Related Issue
Closes AlphaGenes/AlphaImpute2#64
Closes AlphaGenes/AlphaImpute2#58
Closes AlphaGenes/AlphaImpute2#60

Relate to AlphaGenes/AlphaImpute2#59

## What changed
- Add ``-version`` parser
- Modify files as suggested by https://github.com/AlphaGenes/AlphaImpute2/issues/58
- Cannot update ``tinyhouse`` reference as the most recent version of ``tinyhouse``also has the changes for metafounders and X chromosomes, which are incompatible with the current code of the ``AlphaImpute2``.
  - The boilerplate printout mentioned in the AlphaGenes/AlphaImpute2#59 is therefore commented out as a temporary measure. 

## Why this change
Clean up issues

## Notes / Risks
- The recent changes in ``tinyhouse`` is incompatible with current ``AlphaImpute2`` code.